### PR TITLE
Stabilize RTC services and clean up documentation

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,10 +11,11 @@
   ],
   "dependencies": {
     "angular": "~1.3.15",
-    "angular-route": "~1.3.15"
+    "angular-route": "~1.3.15",
+    "angular-sanitize": "~1.3.15"
   },
   "resolutions": {
     "angular": "~1.3.15",
-    "angular-route": "~1.3.15"
+    "angular-route": "~1.3.15",
   }
 }

--- a/client/rtc/audience-rtc.js
+++ b/client/rtc/audience-rtc.js
@@ -2,11 +2,11 @@
 //  - Acquires the user's local media stream right away, upon instantiating
 //  - Connects specifically to the room's presenter.
 // NOTE: The connect method must be passed a room that has a presenter property.
-angular.module('ribbitAudienceRTC', ['ribbitBaseRTC'])
+angular.module('ribbitAudienceRTC', ['ribbitBaseRTC', 'ngSanitize'])
   .factory('audienceRTC', function (baseRTC) {
 
     // Get local media right away
-    // baseRTC.getMedia({ audio: true, video: true }); //TODO: take video out when done debugging
+    baseRTC.getMedia({ audio: true, video: true }); //TODO: take video out when done debugging
 
     baseRTC.connect = function (room, user) {
       this.room = room;

--- a/client/rtc/audience-rtc.js
+++ b/client/rtc/audience-rtc.js
@@ -6,27 +6,13 @@
 
 angular.module('ribbitAudienceRTC', ['ribbitBaseRTC'])
   .factory('audienceRTC', function (baseRTC) {
-
     // Get media right away for audience members
     baseRTC.connect = function (room, user) {
       this.room = room;
       this.me = user;
       this.connectToUser(room.presenter);
     }
-    // baseRTC.getMedia({ video: true, audio: true}, function (stream) {
-    //   document.getElementbyId('local-video').src = window.URL.createObjectURL(stream)
-    // });
     return baseRTC;
-  })
-  .controller('audienceCtrl', function (audienceRTC) {
-    audienceRTC.signalServer.onopen = function () {  //shouldn't have to mess with this here
-      console.log('audience trying to connect')
-      audienceRTC.getMedia({ video: true, audio: true }, function () {
-        //let's see if this works -- only connecting after getMedia
-        audienceRTC.connect({ roomname: 'aviary', presenter: 'fred' }, 'andy3');
-      });
-    }
-  })
-
+  });
 
 

--- a/client/rtc/audience-rtc.js
+++ b/client/rtc/audience-rtc.js
@@ -1,17 +1,20 @@
-// Subclass of RibbitBaseRTC specific to audience member connections:
-// - transmit their audio stream to presenter
-// - handle error and end events (NOT IMPLEMENTED)
-// - connect to a specific room as a specific user (ROOM TBD)
-// var RibbitAudienceRTC = function () {
+// Audience RTC:
+//  - Acquires the user's local media stream right away, upon instantiating
+//  - Connects specifically to the room's presenter.
+// NOTE: The connect method must be passed a room that has a presenter property.
 
 angular.module('ribbitAudienceRTC', ['ribbitBaseRTC'])
   .factory('audienceRTC', function (baseRTC) {
-    // Get media right away for audience members
+
+    // Get local media right away
+    base.getUserMedia({ audio: true, video: true }); //TODO: take video out when done debugging
+
     baseRTC.connect = function (room, user) {
       this.room = room;
       this.me = user;
       this.connectToUser(room.presenter);
     }
+
     return baseRTC;
   });
 

--- a/client/rtc/audience-rtc.js
+++ b/client/rtc/audience-rtc.js
@@ -2,12 +2,11 @@
 //  - Acquires the user's local media stream right away, upon instantiating
 //  - Connects specifically to the room's presenter.
 // NOTE: The connect method must be passed a room that has a presenter property.
-
 angular.module('ribbitAudienceRTC', ['ribbitBaseRTC'])
   .factory('audienceRTC', function (baseRTC) {
 
     // Get local media right away
-    base.getUserMedia({ audio: true, video: true }); //TODO: take video out when done debugging
+    // baseRTC.getMedia({ audio: true, video: true }); //TODO: take video out when done debugging
 
     baseRTC.connect = function (room, user) {
       this.room = room;

--- a/client/rtc/base-rtc.js
+++ b/client/rtc/base-rtc.js
@@ -161,13 +161,29 @@ var makeBaseRTC = function (options) {
 };
 
 
-angular.module('ribbitBaseRTC', [])
-  // .factory('BaseRTC', function () {
-  //   return RibbitBaseRTC; //return constructor!
-  // })
-  .provider('baseRTC', function () {
-    console.log('hey! in the provider')
 
+// We use a provider because there is app-level configuration
+// that should not be hardcoded. Specifically, you must set:
+// - The url of your signal server (requires a socket connection)
+// - The ICE servers that peer connections will use in figuring out
+//   how to talk to each other.
+//
+// This is what a valid config looks like, though your specific config
+// will be different:
+//
+// angular.module('yourApp')
+//  .config(['baseRTCProvider', function(baseRTCProvider) {
+//     baseRTCProvider.setSignalServer('ws://localhost:3434'); 
+//     baseRTCProvider.setPeerConnectionConfig({
+//       'iceServers': [
+//         {'url': 'stun:stun.services.mozilla.com'}, 
+//         {'url': 'stun:stun.l.google.com:19302'}
+//       ]
+//     });
+//   }]);
+
+angular.module('ribbitBaseRTC', [])
+  .provider('baseRTC', function () {
     var signalServer;
     this.setSignalServer = function(url) {
       signalServer = url;
@@ -180,26 +196,19 @@ angular.module('ribbitBaseRTC', [])
 
     this.$get = [function () {
       if (!signalServer) {
-        throw Error('RTC Config Error: you must set the signal server in angular.config: BaseRTCProvider.setSignalServer(<url for your signal server>)');
+        throw Error('RTC Config Error: you must set the signal server in angular.config, e.g.: BaseRTCProvider.setSignalServer("url for your signal server>")');
       }
+      if (!peerConnectionConfig) {
+        throw Error('RTC Config Error: you must set the peer connection configu in angular.config, e.g.: BaseRTCProvider.setPeerConnectionConfig({iceServers: [{url: <url>}, {url: <url>}]})');
+      }
+
       return makeBaseRTC({ 
         signalServer: signalServer, 
         peerConnectionConfig: peerConnectionConfig 
       });
     }]  
   })
-  .config(['baseRTCProvider', function(baseRTCProvider) {
-    console.log('hey! in the confige')
 
-    baseRTCProvider.setSignalServer('ws://localhost:3434'); //normally must be set up by app
-
-    baseRTCProvider.setPeerConnectionConfig({
-      'iceServers': [
-        {'url': 'stun:stun.services.mozilla.com'}, 
-        {'url': 'stun:stun.l.google.com:19302'}
-      ]
-    });
-  }]);
 
 
 

--- a/client/rtc/base-rtc.js
+++ b/client/rtc/base-rtc.js
@@ -9,27 +9,34 @@
 // initializing the base class or extend createConnectionTo.
 
 var makeBaseRTC = function (options) {
-
   var baseRTC = {};
+
+  // Connect to our signal server. We talk with other clients over 
+  // this server in order to establish peer connections to them.
   baseRTC.signalServer = new WebSocket(options.signalServer);
+
+  // Save off config RTCPeerConnection needs to know how to connect
+  // to other clients
   baseRTC.peerConnectionConfig = options.peerConnectionConfig;
 
-  // Index peer connections by remote user.
+  // Maintain multiple peer connections, indexed by remote user
   baseRTC.peerConnections = {};
   
-  // Get local media stream, store it in this.localStream, and add it to all peer connections.
+  // If this client will be streaming media to a peer, getMedia should be
+  // called before initiating the handshake (offer/answer) process. (Adding
+  // a stream after connection is established requires the connection to be 
+  // renegotiated, a process we don't support now.)
+  //
+  // This method retrieves the media streams specified in the constraints
+  // parameter. It saves the streams so we can pass them to our peer connections 
+  // as we connect to them later.
   baseRTC.getMedia = function (constraints, success, error) {
     constraints = constraints || { video: true, audio: true };
     error = error || function () {};
     
     var mediaSuccess = function (stream) {
       this.localStream = stream; 
-      // Add our media stream to any peer connections we already have
-      for (var remote in this.peerConnections) {
-        this.peerConnections[remote].addStream(stream);
-      }
-      // Allow caller to do what they want with the stream
-      success && success(stream);  //onmedia callback -- turn into an event
+      success && success(stream);
     }.bind(this);
 
     navigator.getUserMedia(constraints, mediaSuccess, error)
@@ -72,19 +79,25 @@ var makeBaseRTC = function (options) {
     return pc;
   };
 
-  // Subclasses must implement -- some will connect to a room, others to a user!
+  // Subclasses must implement -- some will connect to a room, others to a user.
+  // In either case, the room is the room they are connecting to. It takes an 
+  // object of the form: { name: 'living room', presenter: 'fred' }. The user
+  // is the user they are connecting as (not who they are connecting to).
   baseRTC.connect = function (room, user) {
-  }
-
-  // Issue a request to all clients in room to send an offer. Clients respond
-  // with an offer that we can then give an answer to. As a rule we only create
-  // offers for individual users, so if we don't know who the users are, we just 
-  // as a group to send us offers.
-  baseRTC.connectToRoom = function (room) {
-    this._send({ 'requester': this.me }, 'everyone', 'request-for-offer'); //TODO: don't use 'everyone' as user. Find a better way to indicate we want to send a message to all clients
+    console.log('ERROR: called connect method on base class. Subclasses must implement .connect');
   };
 
-  // Create peer connection to a specific user
+  // Ask all clients in room to send an offer. They all generate offers that
+  // we can then give an answer to. Why do this? Because we don't know who else
+  // is in the room, so we don't know what peer connections to generate so we can 
+  // create offers. So instead, we ask for offers and now we know which peer 
+  // connections to create.
+  // TODO: fix the hacky way we're sending a message to the entire room. It shouldn't go to 'everyone'
+  baseRTC.connectToRoom = function (room) {
+    this._send({ 'requester': this.me }, 'everyone', 'request-for-offer'); 
+  };
+
+  // Create peer connection to a specific user and send them an offer. 
   baseRTC.connectToUser = function (remoteUser) {
     var pc = this.getPeerConnection(remoteUser);
     pc.createOffer(function(description) {
@@ -94,7 +107,10 @@ var makeBaseRTC = function (options) {
     }.bind(this), function (err) { console.log('offer erorr: ', err)});
   };
 
-  // Helper method to send a message to a specific recipient
+  // Helper method to send a message to a specific recipient. Make sure all 
+  // messages are sent with a similar format. In particular, we need all messages
+  // to have a sender, recipient, toom, and type. Otherwise, our onmessage handler
+  // doesn't know what to do. See the handler for details on how these fields are used.
   baseRTC._send = function (message, recipient, messageType) {
     this.signalServer.send(JSON.stringify({
       sender: this.me,
@@ -105,72 +121,87 @@ var makeBaseRTC = function (options) {
     }));
   };
 
-  // See _send for message.data structure
-  baseRTC._gotSignalMessage = function (message) {
+  // Handle incoming messages. Message structure is described in _send.
+  var onMessage = function (message) {
     var data = JSON.parse(message.data);
+
+    // Screen out messages we don't care about. This is a hack to make up 
+    // for the signal server sending everything to everyone. Really, the
+    // signal server should send a message if and only if we need to see it.
+    if (!data.sender) return;
+    if (data.recipient !== this.me && 
+        (data.recipient !== 'everyone' || 
+          data.sender === this.me)) {
+          return;
+    }           
+    // Super useful for debugging. Most issues are somewhere in this function.
     console.log(data);
-    if (!data.sender) return; // just ignore, though ultimately, server shouldn't send these
-    //TODO: find a better way to indicate a message goes to everyone (at least include room check)
-    if (data.recipient !== this.me && (data.recipient !== 'everyone' || data.sender === this.me)) { // || data.room !== this.room)) {
-      return; // not addressed to me... signal server shouldn't have sent to me in the first place
-    }      
-    
+
     // get peer connection for sender (or create one if we don't have one yet)
     var pc = this.getPeerConnection(data.sender);
 
-    // Respond to offer by setting new pc's remote description and sending an answer
-    // that contains our description
+    // Respond to offer with our answer, updating our remote and local descriptions
+    // in the process
     if (data.type === 'offer') {
-      var self = this;
-      var logErr = console.log.bind(console);
+      var self = this; //for _send below
       pc.setRemoteDescription(new RTCSessionDescription(data.contents), function () {
         pc.createAnswer(function (answer) {
           pc.setLocalDescription(answer, function () {
             self._send(answer, data.sender, 'answer');
-          }, logErr);
-        }, logErr);
-      }, logErr);
+          });
+        });
+      });
 
     // Respond to answers by just updating our remote description 
     } else if (data.type === 'answer') {
       pc.setRemoteDescription(new RTCSessionDescription(data.contents));
-    // Add ICE Candidates as they come in
+
+    // Add ICE Candidates as they come in -- the remote peer's oneicecandidate handler sends these
     } else if (data.type === 'ice') {
       pc.addIceCandidate(new RTCIceCandidate(data.contents.ice));
+
     // Send an offer if asked  
     } else if (data.type === 'request-for-offer') {
       this.connectToUser(data.contents.requester);
+
+    // Oops! Where'd this message come from?
+    } else {
+      console.log('baseRTC:onMessage - unhandled message type: ' + data.type, data);
     }
   };
+  
+  // Use onMessage to handle messages coming from signal server
+  baseRTC.signalServer.onmessage = onMessage.bind(baseRTC);
 
-  baseRTC.signalServer.onmessage = baseRTC._gotSignalMessage.bind(baseRTC);
-
+  // Peer connections emit events, like onaddstream and onremovestream.
+  // We need to provide a way to allow consumers of our service to 
+  // register handlers for these events. This is how we're doing it 
+  // now -- not super robust, but it works.
   var handlers = baseRTC.handlers = {};
   baseRTC.on = function (event, handler) {
-    //add to existing connections
+    // add to existing connections
     for (var u in this.peerConnections) {
       this.peerConnections[u][event] = handler;
     }
+    // save so we can add to peer connections we create in the future
     handlers[event] = handler //only one handler per event for now
-    //save so we can add to future connections
-    // handlers[event] = handlers[event] || [];
-    // handlers[event].push(handler);
   };
   return baseRTC;
 
 };
 
-
-
+// ********************
+//    Angularization
+// ********************
 // We use a provider because there is app-level configuration
 // that should not be hardcoded. Specifically, you must set:
-// - The url of your signal server (requires a socket connection)
+// - The url of your signal server (which must use sockets)
 // - The ICE servers that peer connections will use in figuring out
 //   how to talk to each other.
 //
 // This is what a valid config looks like, though your specific config
 // will be different:
-//
+// ```
 // angular.module('yourApp')
 //  .config(['baseRTCProvider', function(baseRTCProvider) {
 //     baseRTCProvider.setSignalServer('ws://localhost:3434'); 
@@ -181,6 +212,7 @@ var makeBaseRTC = function (options) {
 //       ]
 //     });
 //   }]);
+// ```
 
 angular.module('ribbitBaseRTC', [])
   .provider('baseRTC', function () {

--- a/client/rtc/mvp-example/audience-1.html
+++ b/client/rtc/mvp-example/audience-1.html
@@ -17,6 +17,18 @@
             });
           }
         })
+        .config(['baseRTCProvider', function(baseRTCProvider) {
+          console.log('hey! in the confige')
+
+          baseRTCProvider.setSignalServer('ws://localhost:3434'); //normally must be set up by app
+
+          baseRTCProvider.setPeerConnectionConfig({
+            'iceServers': [
+              {'url': 'stun:stun.services.mozilla.com'}, 
+              {'url': 'stun:stun.l.google.com:19302'}
+            ]
+          });
+        }]);
     </script>
   </head>
   <body ng-app="ribbitAudienceRTC" ng-controller="audienceCtrl">

--- a/client/rtc/mvp-example/audience-1.html
+++ b/client/rtc/mvp-example/audience-1.html
@@ -5,21 +5,22 @@
     <script src="../rtc-normalizer.js"></script>
     <script src="../base-rtc.js"></script>
     <script src="../audience-rtc.js"></script>
+    <script type="text/javascript">
+      angular.module('ribbitAudienceRTC')
+        .controller('audienceCtrl', function (audienceRTC) {
+          audienceRTC.signalServer.onopen = function () {  //shouldn't have to mess with this here
+            console.log('audience trying to connect')
+            audienceRTC.getMedia({ video: true, audio: true }, function (stream) {
+              var videoEl = document.getElementById('local-video');
+              videoEl.src = window.URL.createObjectURL(stream);          
+              audienceRTC.connect({ roomname: 'aviary', presenter: 'fred' }, 'ryan');
+            });
+          }
+        })
+    </script>
   </head>
   <body ng-app="ribbitAudienceRTC" ng-controller="audienceCtrl">
     <h1>Local Video</h1>
     <video id="local-video" autoplay muted style="width:40%;"></video>
-    <!-- <video id="remote-video" autoplay muted style="width:40%;"></video> -->
-    <br>
-    <!-- <input type="button" onclick="connect()" id="start" value="Start Video"> -->
-    <script type="text/javascript">
-      // var audienceRTC = new RibbitAudienceRTC('sungmin', {
-      //   onmedia: function(stream) {
-      //     var videoEl = document.getElementById('local-video');
-      //     videoEl.src = window.URL.createObjectURL(stream);          
-      //     audienceRTC.connect();      
-      //   }
-      // });
-    </script>
   </body>
 </html>

--- a/client/rtc/mvp-example/audience-1.html
+++ b/client/rtc/mvp-example/audience-1.html
@@ -2,20 +2,30 @@
 <html>
   <head>
     <script src="../../lib/angular/angular.js"></script>
+    <script src="../../lib/angular-sanitize/angular-sanitize.js"></script>
     <script src="../rtc-normalizer.js"></script>
     <script src="../base-rtc.js"></script>
     <script src="../audience-rtc.js"></script>
     <script type="text/javascript">
       angular.module('ribbitAudienceRTC')
-        .controller('audienceCtrl', function (audienceRTC) {
-          audienceRTC.signalServer.onopen = function () {  //shouldn't have to mess with this here
-            console.log('audience trying to connect')
-            audienceRTC.getMedia({ video: true, audio: true }, function (stream) {
-              var videoEl = document.getElementById('local-video');
-              videoEl.src = window.URL.createObjectURL(stream);          
-              audienceRTC.connect({ roomname: 'aviary', presenter: 'fred' }, 'ryan');
-            });
-          }
+        .controller('audienceCtrl', function ($scope, $sce, audienceRTC) {
+          // only connect after ready (signal server is up, we have a media stream)
+          audienceRTC.ready(function () {
+
+            // access local media stream in audienceRTC.localStream
+            // to use as a src in the DOM, you must run it through a couple functions:
+            // - window.URL.createObjectURL to transform the stream object into a blob URL
+            // - $sce.trustAsResourceUrl to let angular know it can trust the blob URL
+            //   you need to inject $sce as a dependency (part of angular-sanitize, included in baseRTC)
+            $scope.localStream = $sce.trustAsResourceUrl(window.URL.createObjectURL(audienceRTC.localStream));
+
+            // connect now that our signal server is ready
+            audienceRTC.connect({ roomname: 'aviary', presenter: 'fred' }, 'ryan');
+
+            // if you your handler updates the $scope, you need to call $scope.$apply
+            // so angular knows to run a digest.
+            $scope.$apply();
+          })
         })
         .config(['baseRTCProvider', function(baseRTCProvider) {
           console.log('hey! in the confige')
@@ -33,6 +43,6 @@
   </head>
   <body ng-app="ribbitAudienceRTC" ng-controller="audienceCtrl">
     <h1>Local Video</h1>
-    <video id="local-video" autoplay muted style="width:40%;"></video>
+    <video id="local-video" autoplay muted style="width:40%;" ng-src="{{localStream}}"></video>
   </body>
 </html>

--- a/client/rtc/mvp-example/audience-2.html
+++ b/client/rtc/mvp-example/audience-2.html
@@ -17,6 +17,18 @@
             });
           }
         })
+        .config(['baseRTCProvider', function(baseRTCProvider) {
+          console.log('hey! in the confige')
+
+          baseRTCProvider.setSignalServer('ws://localhost:3434'); //normally must be set up by app
+
+          baseRTCProvider.setPeerConnectionConfig({
+            'iceServers': [
+              {'url': 'stun:stun.services.mozilla.com'}, 
+              {'url': 'stun:stun.l.google.com:19302'}
+            ]
+          });
+        }]);
     </script>
   </head>
   <body ng-app="ribbitAudienceRTC" ng-controller="audienceCtrl">

--- a/client/rtc/mvp-example/audience-2.html
+++ b/client/rtc/mvp-example/audience-2.html
@@ -1,24 +1,26 @@
 <!doctype html>
 <html>
   <head>
+    <script src="../../lib/angular/angular.js"></script>
     <script src="../rtc-normalizer.js"></script>
     <script src="../base-rtc.js"></script>
     <script src="../audience-rtc.js"></script>
+    <script type="text/javascript">
+      angular.module('ribbitAudienceRTC')
+        .controller('audienceCtrl', function (audienceRTC) {
+          audienceRTC.signalServer.onopen = function () {  //shouldn't have to mess with this here
+            console.log('audience trying to connect')
+            audienceRTC.getMedia({ video: true, audio: true }, function (stream) {
+              var videoEl = document.getElementById('local-video');
+              videoEl.src = window.URL.createObjectURL(stream);          
+              audienceRTC.connect({ roomname: 'aviary', presenter: 'fred' }, 'andy');
+            });
+          }
+        })
+    </script>
   </head>
-  <body>
+  <body ng-app="ribbitAudienceRTC" ng-controller="audienceCtrl">
     <h1>Local Video</h1>
     <video id="local-video" autoplay muted style="width:40%;"></video>
-    <!-- <video id="remote-video" autoplay muted style="width:40%;"></video> -->
-    <br>
-    <!-- <input type="button" onclick="connect()" id="start" value="Start Video"> -->
-    <script type="text/javascript">
-      var audienceRTC = new RibbitAudienceRTC('andy', {
-        onmedia: function(stream) {
-          var videoEl = document.getElementById('local-video');
-          videoEl.src = window.URL.createObjectURL(stream);          
-          audienceRTC.connect();      
-        }
-      });
-    </script>
   </body>
 </html>

--- a/client/rtc/mvp-example/audience-3.html
+++ b/client/rtc/mvp-example/audience-3.html
@@ -17,6 +17,18 @@
             });
           }
         })
+        .config(['baseRTCProvider', function(baseRTCProvider) {
+          console.log('hey! in the confige')
+
+          baseRTCProvider.setSignalServer('ws://localhost:3434'); //normally must be set up by app
+
+          baseRTCProvider.setPeerConnectionConfig({
+            'iceServers': [
+              {'url': 'stun:stun.services.mozilla.com'}, 
+              {'url': 'stun:stun.l.google.com:19302'}
+            ]
+          });
+        }]);
     </script>
   </head>
   <body ng-app="ribbitAudienceRTC" ng-controller="audienceCtrl">

--- a/client/rtc/mvp-example/audience-3.html
+++ b/client/rtc/mvp-example/audience-3.html
@@ -1,24 +1,26 @@
 <!doctype html>
 <html>
   <head>
+    <script src="../../lib/angular/angular.js"></script>
     <script src="../rtc-normalizer.js"></script>
     <script src="../base-rtc.js"></script>
     <script src="../audience-rtc.js"></script>
+    <script type="text/javascript">
+      angular.module('ribbitAudienceRTC')
+        .controller('audienceCtrl', function (audienceRTC) {
+          audienceRTC.signalServer.onopen = function () {  //shouldn't have to mess with this here
+            console.log('audience trying to connect')
+            audienceRTC.getMedia({ video: true, audio: true }, function (stream) {
+              var videoEl = document.getElementById('local-video');
+              videoEl.src = window.URL.createObjectURL(stream);          
+              audienceRTC.connect({ roomname: 'aviary', presenter: 'fred' }, 'brian');
+            });
+          }
+        })
+    </script>
   </head>
-  <body>
+  <body ng-app="ribbitAudienceRTC" ng-controller="audienceCtrl">
     <h1>Local Video</h1>
     <video id="local-video" autoplay muted style="width:40%;"></video>
-    <!-- <video id="remote-video" autoplay muted style="width:40%;"></video> -->
-    <br>
-    <!-- <input type="button" onclick="connect()" id="start" value="Start Video"> -->
-    <script type="text/javascript">
-      var audienceRTC = new RibbitAudienceRTC('brian', {
-        onmedia: function(stream) {
-          var videoEl = document.getElementById('local-video');
-          videoEl.src = window.URL.createObjectURL(stream);          
-          audienceRTC.connect();      
-        }
-      });
-    </script>
   </body>
 </html>

--- a/client/rtc/mvp-example/audience-4.html
+++ b/client/rtc/mvp-example/audience-4.html
@@ -17,6 +17,18 @@
             });
           }
         })
+        .config(['baseRTCProvider', function(baseRTCProvider) {
+          console.log('hey! in the confige')
+
+          baseRTCProvider.setSignalServer('ws://localhost:3434'); //normally must be set up by app
+
+          baseRTCProvider.setPeerConnectionConfig({
+            'iceServers': [
+              {'url': 'stun:stun.services.mozilla.com'}, 
+              {'url': 'stun:stun.l.google.com:19302'}
+            ]
+          });
+        }]);
     </script>
   </head>
   <body ng-app="ribbitAudienceRTC" ng-controller="audienceCtrl">

--- a/client/rtc/mvp-example/audience-4.html
+++ b/client/rtc/mvp-example/audience-4.html
@@ -1,24 +1,26 @@
 <!doctype html>
 <html>
   <head>
+    <script src="../../lib/angular/angular.js"></script>
     <script src="../rtc-normalizer.js"></script>
     <script src="../base-rtc.js"></script>
     <script src="../audience-rtc.js"></script>
+    <script type="text/javascript">
+      angular.module('ribbitAudienceRTC')
+        .controller('audienceCtrl', function (audienceRTC) {
+          audienceRTC.signalServer.onopen = function () {  //shouldn't have to mess with this here
+            console.log('audience trying to connect')
+            audienceRTC.getMedia({ video: true, audio: true }, function (stream) {
+              var videoEl = document.getElementById('local-video');
+              videoEl.src = window.URL.createObjectURL(stream);          
+              audienceRTC.connect({ roomname: 'aviary', presenter: 'fred' }, 'sungmin');
+            });
+          }
+        })
+    </script>
   </head>
-  <body>
+  <body ng-app="ribbitAudienceRTC" ng-controller="audienceCtrl">
     <h1>Local Video</h1>
     <video id="local-video" autoplay muted style="width:40%;"></video>
-    <!-- <video id="remote-video" autoplay muted style="width:40%;"></video> -->
-    <br>
-    <!-- <input type="button" onclick="connect()" id="start" value="Start Video"> -->
-    <script type="text/javascript">
-      var audienceRTC = new RibbitAudienceRTC('ryan', {
-        onmedia: function(stream) {
-          var videoEl = document.getElementById('local-video');
-          videoEl.src = window.URL.createObjectURL(stream);          
-          audienceRTC.connect();      
-        }
-      });
-    </script>
   </body>
 </html>

--- a/client/rtc/mvp-example/presenter.html
+++ b/client/rtc/mvp-example/presenter.html
@@ -18,28 +18,34 @@
       }
 
       angular.module('ribbitPresenterRTC')
-        .controller('presenterCtrl', function($scope, presenterRTC) {
-          $scope.streams = [];
+        .controller('presenterCtrl', function($scope, $sce, presenterRTC) {
+          $scope.connections = [];
 
-          presenterRTC.signalServer.onopen = function () {
-            presenterRTC.connect('aviary', 'fred');  // presenter subclass knows how to handle this
-          }
-
-          presenterRTC.on('onaddstream', function (event) {
-            console.log('got remote stream!');
-            addVideoElem(event.stream);
-            // var streamSrc = $sce.trustAsResourceUrl(window.URL.createObjectURL(event.stream));
-            // $scope.streams.push(streamSrc);
-            // $scope.$apply();
+          // only connect once our RTC manager is ready!
+          presenterRTC.ready(function () {
+            // the first arg here is teh room object, the second is who we're connecting as
+            presenterRTC.connect({ name: 'aviary', presenter: 'fred'}, 'fred'); 
           });
 
-          // presenterRTC.on('removeremotestream', function (pc) {})
-          // presenterRTC.on('audienceConnect', function (pc) {})
-          // presenterRTC.on('audienceLeave', function (pc) {})
-          // presenterRTC.on('audience speak', function (pc) {})
-          // presenterRTC.on('audience stop speaking', function (pc) {})
-          // presenter.connect('backbone lecture', 'fred', function() {'success!'});
-          // presenterRTC.closeAllConnections()
+          // register event handlers for peer connection events. MDN has a description of these events.
+          // the remote user and peerconnection object are the last two arguments for any handler
+          presenterRTC.on('onaddstream', function (event, remoteUser, pc) {
+            // For onaddstream, you need to look in event.stream to get the media stream
+            // See audience-1.html for description of trustAsResourceUrl and createObjectURL -- you need both!
+            // NOTE: this doesn't yet seem to work when the stream is remote, though I'm pretty sure it should.
+            // if you don't go through angular and instead just set the src w/vanillaJS it does work, so things
+            // are fine on the RTC side...
+            var stream = $sce.trustAsResourceUrl(window.URL.createObjectURL(event.stream));
+            var connection = {
+              stream: stream,
+              user: remoteUser
+            };
+            $scope.connections.push(connection)
+
+            // must call $scope.$apply so angular knows to run a digest
+            $scope.$apply();
+          });
+
         })
         .config(['baseRTCProvider', function(baseRTCProvider) {
           console.log('hey! in the confige')
@@ -58,11 +64,12 @@
     </script>
   </head>
   <body ng-app="ribbitPresenterRTC" ng-controller="presenterCtrl">
-    <div id="videos"></div>
-<!--     <h1>Audience Video</h1>
-    Stream count: {{streams.length}}
-    <div ng-repeat="stream in streams">
-      <video autoplay muted src="{{stream}}" style="width:40%;"></video>
-    </div> -->
+    <h1>Audience Video</h1>
+    Connections count: {{connections.length}}
+    <div ng-repeat="connection in connections">
+
+      <video autoplay muted ng-src="{{connection.stream}}" style="width:40%;"></video>
+      {{connection.user}}
+    </div>
   </body>
 </html>

--- a/client/rtc/mvp-example/presenter.html
+++ b/client/rtc/mvp-example/presenter.html
@@ -41,6 +41,18 @@
           // presenter.connect('backbone lecture', 'fred', function() {'success!'});
           // presenterRTC.closeAllConnections()
         })
+        .config(['baseRTCProvider', function(baseRTCProvider) {
+          console.log('hey! in the confige')
+
+          baseRTCProvider.setSignalServer('ws://localhost:3434'); //normally must be set up by app
+
+          baseRTCProvider.setPeerConnectionConfig({
+            'iceServers': [
+              {'url': 'stun:stun.services.mozilla.com'}, 
+              {'url': 'stun:stun.l.google.com:19302'}
+            ]
+          });
+        }]);
 
 
     </script>

--- a/client/rtc/mvp-example/presenter.html
+++ b/client/rtc/mvp-example/presenter.html
@@ -7,6 +7,43 @@
     <script src="../rtc-normalizer.js"></script>
     <script src="../base-rtc.js"></script>
     <script src="../presenter-rtc.js"></script>
+    <script type="text/javascript">
+      var addVideoElem = function (stream) {
+        console.log('adding video!')
+        var vid = document.createElement('video');
+        vid.muted = true;
+        vid.autoplay = true;
+        vid.src = window.URL.createObjectURL(stream); 
+        document.getElementById('videos').appendChild(vid);
+      }
+
+      angular.module('ribbitPresenterRTC')
+        .controller('presenterCtrl', function($scope, presenterRTC) {
+          $scope.streams = [];
+
+          presenterRTC.signalServer.onopen = function () {
+            presenterRTC.connect('aviary', 'fred');  // presenter subclass knows how to handle this
+          }
+
+          presenterRTC.on('onaddstream', function (event) {
+            console.log('got remote stream!');
+            addVideoElem(event.stream);
+            // var streamSrc = $sce.trustAsResourceUrl(window.URL.createObjectURL(event.stream));
+            // $scope.streams.push(streamSrc);
+            // $scope.$apply();
+          });
+
+          // presenterRTC.on('removeremotestream', function (pc) {})
+          // presenterRTC.on('audienceConnect', function (pc) {})
+          // presenterRTC.on('audienceLeave', function (pc) {})
+          // presenterRTC.on('audience speak', function (pc) {})
+          // presenterRTC.on('audience stop speaking', function (pc) {})
+          // presenter.connect('backbone lecture', 'fred', function() {'success!'});
+          // presenterRTC.closeAllConnections()
+        })
+
+
+    </script>
   </head>
   <body ng-app="ribbitPresenterRTC" ng-controller="presenterCtrl">
     <div id="videos"></div>
@@ -15,20 +52,5 @@
     <div ng-repeat="stream in streams">
       <video autoplay muted src="{{stream}}" style="width:40%;"></video>
     </div> -->
-    <script type="text/javascript">
-      // var addVideoElem = function (stream) {
-      //   console.log('adding video!')
-      //   var vid = document.createElement('video');
-      //   vid.muted = true;
-      //   vid.autoplay = true;
-      //   vid.src = window.URL.createObjectURL(event.stream); 
-      //   document.getElementById('videos').appendChild(vid);
-      // }
-      // var presenterRTC = new RibbitPresenterRTC('fred', {
-      //   onaddstream: function (event) {
-      //     addVideoElem(event.stream);
-      //   }
-      // });
-    </script>
   </body>
 </html>

--- a/client/rtc/presenter-rtc.js
+++ b/client/rtc/presenter-rtc.js
@@ -1,66 +1,17 @@
-//TODO:
-// - Move onaddstream handling to BaseRTC as general pc event handling
-// - Add onremovestream
-angular.module('ribbitPresenterRTC', ['ribbitBaseRTC']) //need ngSanitize for blob url: 
-  .factory('presenterRTC', function (baseRTC) {
+// PresenterRTC has two unique features:
+// - Its connect method establishes a peer connection with each
+//   audience member in the room. It does this by asking everyone 
+//   in the room to send an offer for it can respond to
+// - It does not get a local media stream
 
+angular.module('ribbitPresenterRTC', ['ribbitBaseRTC'])
+  .factory('presenterRTC', function (baseRTC) {
+    
     baseRTC.connect = function(room, name) {
       this.room = room;
       this.me = name;
-      this.connectToRoom(this.room); //TODO: check w/team on room object
+      this.connectToRoom(this.room); 
     }
+
     return baseRTC;
   })
-  .controller('presenterCtrl', function($scope, presenterRTC) {
-
-    $scope.streams = [];
-
-    presenterRTC.signalServer.onopen = function () {
-      presenterRTC.connect('aviary', 'fred');  // presenter subclass knows how to handle this
-    }
-
-    var addVideoElem = function (stream) {
-      console.log('adding video!')
-      var vid = document.createElement('video');
-      vid.muted = true;
-      vid.autoplay = true;
-      vid.src = window.URL.createObjectURL(stream); 
-      document.getElementById('videos').appendChild(vid);
-    }
-
-
-    presenterRTC.on('onaddstream', function (event) {
-      console.log('got remote stream!');
-      addVideoElem(event.stream);
-      // var streamSrc = $sce.trustAsResourceUrl(window.URL.createObjectURL(event.stream));
-      // $scope.streams.push(streamSrc);
-      // $scope.$apply();
-
-    });
-
-
-    // presenterRTC.on('removeremotestream', function (pc) {
-    //   console.log('remotestream gone :(')
-    // });
-
-    // presenterRTC.on('audienceConnect', function (pc) {
-    //   console.log('audience connected');
-    // });
-
-    // presenterRTC.on('audienceLeave', function (pc) {
-
-    // });
-
-    // presenterRTC.on('audience speak', function (pc) {
-
-    // })
-
-    // presenterRTC.on('audience stop speaking', function (pc) {
-
-    // })
-
-    // presenter.connect('backbone lecture', 'fred', function() {'success!'});
-
-    // presenterRTC.closeAllConnections()
-  })
-


### PR DESCRIPTION
This PR does a few things for the RTC services:
- stabilizes them, so peers can now connect in any order and can reconnect on refresh
- adds a ready() method, so you can make sure the RTC object is ready before trying to connect
- moves sample config and controller code out of the service files
- cleans up the documentation
